### PR TITLE
ci: migrate runner from lux-build to hanzo-build (ARC consolidation)

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Publish to NPM
-    runs-on: lux-build-linux-amd64
+    runs-on: hanzo-build-linux-amd64
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary
- Migrate `publish-on-tag.yml` publish job from `lux-build-linux-amd64` → `hanzo-build-linux-amd64`.
- Part of ARC fleet consolidation: one and only one canonical self-hosted runner pool for hanzo/lux/zoo/liquidity.
- Capacity identical — hanzo-build-linux-amd64 is max 30 (DO ARC), plus hanzo-build-linux-arm64 (max 30, GKE T2A Ampere) for ARM.

## Why
Duplicate scale sets (lux-build-* and hanzo-build-*) violate "one way to do everything". The hanzo ARC is the canonical fleet per hanzo/CLAUDE.md. After this and the matching lux/universe PR lands, the lux-build-linux-amd64 scale set spins down to 0 replicas.

## Test plan
- [ ] Next tag push schedules publish job on hanzo-build-linux-amd64
- [ ] NPM publish completes green with no runner-lookup errors
- [ ] Published packages identical to prior releases