### PR TITLE
fix(web): kill @hanzogui/react-native-reanimated fork + cross-org defaults

### DIFF
--- a/apps/web/src/appGraphql/data/apollo/client.ts
+++ b/apps/web/src/appGraphql/data/apollo/client.ts
@@ -4,7 +4,8 @@ import { setupSharedApolloCache } from '@l.x/lx/src/data/cache'
 import { getDatadogApolloLink } from '@l.x/utils/src/logger/datadog/datadogLink'
 import { getRetryLink } from '~/appGraphql/data/apollo/retryLink'
 
-const API_URL = process.env.REACT_APP_AWS_API_ENDPOINT || 'https://api-exchange.lux.network/v1/graphql'
+// Default to the live Lux Gateway. White-label builds override via REACT_APP_AWS_API_ENDPOINT.
+const API_URL = process.env.REACT_APP_AWS_API_ENDPOINT || 'https://dex.lux.network/v1/graphql'
 
 const httpLink = new HttpLink({ uri: API_URL })
 const datadogLink = getDatadogApolloLink()

--- a/apps/web/src/state/explore/luxSubgraph.ts
+++ b/apps/web/src/state/explore/luxSubgraph.ts
@@ -9,10 +9,12 @@ import { useQuery } from '@tanstack/react-query'
 // ─── Constants ─────────────────────────────────────────────────────
 
 export const LUX_CHAIN_ID = 96369
+// Default to the live Lux Gateway (luxfi/dex). White-labels (liquidity,
+// zoo, pars) override via REACT_APP_GRAPH_ENGINE_URL at build time.
 export const GRAPH_ENGINE_URL =
   process.env.REACT_APP_GRAPH_ENGINE_URL ||
   process.env.NEXT_PUBLIC_GRAPH_ENGINE_URL ||
-  'https://api-exchange.lux.network/v1/graphql'
+  'https://dex.lux.network/v1/graphql'
 
 // ─── Types ─────────────────────────────────────────────────────────
 

--- a/apps/web/src/state/explore/useExchangeStats.ts
+++ b/apps/web/src/state/explore/useExchangeStats.ts
@@ -22,11 +22,12 @@ import {
   type PublicPool,
 } from './publicTokenData'
 
-// V3 graph engine endpoint — served by luxfi/graph, proxied through exchange ingress
+// V3 graph engine endpoint — Lux Gateway (luxfi/dex) by default; white-label
+// builds override via REACT_APP_GRAPH_ENGINE_URL.
 const GRAPH_ENGINE_URL =
   process.env.REACT_APP_GRAPH_ENGINE_URL ||
   process.env.NEXT_PUBLIC_GRAPH_ENGINE_URL ||
-  'https://api-exchange.lux.network/v1/graphql'
+  'https://dex.lux.network/v1/graphql'
 
 function chainIdToGqlChain(chainId: number): string {
   return CHAIN_TO_GQL[chainId] ?? GraphQLApi.Chain.Ethereum

--- a/apps/web/src/stubs/react-native-reanimated.ts
+++ b/apps/web/src/stubs/react-native-reanimated.ts
@@ -1,0 +1,95 @@
+// Web stub for react-native-reanimated.
+//
+// All animation work on web goes through CSS transitions or Tamagui's
+// own animation system; reanimated is mobile-only here. Source files
+// that actually use reanimated are .native.tsx and excluded from the
+// web build by Vite's platform-extension resolution.
+//
+// What's left importing reanimated on web is a tiny set:
+//   • apps/web/src/index.tsx → configureReanimatedLogger()
+//   • pkgs/lx/.../modalConstants.tsx → Easing
+//   • pkgs/lx/.../ModalProps.tsx    → type SharedValue
+//
+// This stub provides exactly those — no broken-fork dependency, no
+// JSX-in-.js packaging bugs to transpile around.
+
+export type SharedValue<T> = { value: T }
+
+export function configureReanimatedLogger(_options?: unknown): void {
+  // no-op — web has no reanimated runtime to configure
+}
+
+const linear = (t: number) => t
+const ease = (t: number) => t * t * (3 - 2 * t)
+
+export const Easing = {
+  linear,
+  ease,
+  quad: (t: number) => t * t,
+  cubic: (t: number) => t * t * t,
+  in: (fn: (t: number) => number) => fn,
+  out: (fn: (t: number) => number) => (t: number) => 1 - fn(1 - t),
+  inOut: (fn: (t: number) => number) => (t: number) => (t < 0.5 ? fn(2 * t) / 2 : 1 - fn(2 * (1 - t)) / 2),
+  bezier: (_a: number, _b: number, _c: number, _d: number) => linear,
+  bezierFn: (_a: number, _b: number, _c: number, _d: number) => linear,
+  steps: (_n: number, _modifier?: 'jump-start' | 'jump-end' | 'jump-none' | 'jump-both') => linear,
+  poly: (_n: number) => linear,
+  sin: (t: number) => Math.sin((t * Math.PI) / 2),
+  circle: (t: number) => 1 - Math.sqrt(1 - t * t),
+  exp: (t: number) => Math.pow(2, 10 * (t - 1)),
+  back: () => (t: number) => t * t * (2.7 * t - 1.7),
+  bounce: (t: number) => (t < 0.5 ? 8 * t * t * t * t : 1 - 8 * Math.pow(1 - t, 4)),
+  elastic: () => linear,
+}
+
+export const Extrapolate = { CLAMP: 'clamp', EXTEND: 'extend', IDENTITY: 'identity' } as const
+export const Extrapolation = Extrapolate
+
+export function useSharedValue<T>(initial: T): SharedValue<T> {
+  return { value: initial }
+}
+export function useDerivedValue<T>(fn: () => T): SharedValue<T> {
+  return { value: fn() }
+}
+export function useAnimatedStyle<T>(fn: () => T): T {
+  return fn()
+}
+export function useAnimatedProps<T>(fn: () => T): T {
+  return fn()
+}
+export function withTiming<T>(value: T): T {
+  return value
+}
+export function withSpring<T>(value: T): T {
+  return value
+}
+export function withRepeat<T>(value: T): T {
+  return value
+}
+export function withSequence<T>(...values: T[]): T {
+  return values[values.length - 1]
+}
+export function withDelay<T>(_delay: number, value: T): T {
+  return value
+}
+export function interpolate(_value: number, _input: readonly number[], output: readonly number[]): number {
+  return output[0] ?? 0
+}
+export function runOnJS<F extends (...args: unknown[]) => unknown>(fn: F): F {
+  return fn
+}
+export function runOnUI<F extends (...args: unknown[]) => unknown>(fn: F): F {
+  return fn
+}
+
+export const FadeIn = { duration: () => FadeIn }
+export const FadeOut = { duration: () => FadeOut }
+
+const Animated = {
+  View: 'div',
+  Text: 'span',
+  Image: 'img',
+  ScrollView: 'div',
+  createAnimatedComponent: <T,>(component: T): T => component,
+}
+export default Animated

--- a/apps/web/src/tracing/insights.ts
+++ b/apps/web/src/tracing/insights.ts
@@ -2,8 +2,13 @@ import { brand } from '@l.x/config'
 import { isTestEnv } from '@l.x/utils/src/environment/env'
 import { logger } from '@l.x/utils/src/logger/logger'
 
-const INSIGHTS_API_KEY = process.env.REACT_APP_INSIGHTS_API_KEY || 'hi_a5316882b930d11c9183007d70c3955b'
-const INSIGHTS_HOST = process.env.REACT_APP_INSIGHTS_HOST || 'https://insights.hanzo.ai'
+// Insights is fully opt-in via env. No hardcoded API key or host —
+// white-label builds (liquidity, zoo) self-host their own insights and
+// supply their own keys; the canonical Lux build supplies its own.
+// When unset, setupInsights becomes a no-op so we never leak telemetry
+// to a host the consuming brand didn't configure.
+const INSIGHTS_API_KEY = process.env.REACT_APP_INSIGHTS_API_KEY || ''
+const INSIGHTS_HOST = process.env.REACT_APP_INSIGHTS_HOST || ''
 
 let insightsClient: any = null
 
@@ -14,6 +19,11 @@ export function getInsightsClient() {
 export async function setupInsights() {
   if (isTestEnv()) {
     logger.debug('insights.ts', 'setupInsights', 'Skipping Insights initialization in test environment')
+    return
+  }
+
+  if (!INSIGHTS_API_KEY || !INSIGHTS_HOST) {
+    logger.debug('insights.ts', 'setupInsights', 'Insights not configured (REACT_APP_INSIGHTS_HOST/API_KEY unset) — skipping')
     return
   }
 

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -209,6 +209,12 @@ export default defineConfig(({ mode }) => {
   const overrides = {
     // External package aliases
     'react-native': 'react-native-web',
+    // Web stub for reanimated — the only call sites surviving Vite's
+    // .native.tsx resolution are configureReanimatedLogger / Easing /
+    // type SharedValue. This alias bypasses the @hanzogui fork entirely
+    // (which ships raw JSX in lib/module/**/*.js and an off-spec
+    // 3.19.3-fork.1 version that breaks Rollup's commonjs-resolver).
+    'react-native-reanimated': path.resolve(__dirname, 'src/stubs/react-native-reanimated.ts'),
     'expo-blur': path.resolve(__dirname, 'src/lib/expo-blur-mock.jsx'),
     '@web3-react/core': path.resolve(__dirname, 'src/connection/web3reactShim.ts'),
     '@l.x/lx/src': path.resolve(__dirname, '../../pkgs/lx/src'),
@@ -459,29 +465,10 @@ export default defineConfig(({ mode }) => {
           }
         },
       },
-      {
-        name: 'transform-react-native-jsx',
-        async transform(code: string, id: string) {
-          // Transform JSX in react-native libraries that ship JSX in .js files
-          const needsJsxTransform = [
-            'node_modules/react-native-reanimated',
-            'node_modules/expo-blur'  // In case it's not fully mocked
-          ].some(path => id.includes(path))
-
-          if (!needsJsxTransform || !id.endsWith('.js')) {
-            return null
-          }
-
-          // Dynamic import to avoid top-level import issues
-          const { transformWithEsbuild } = await import('vite')
-
-          // Use Vite's transformWithEsbuild to handle JSX
-          return transformWithEsbuild(code, id, {
-            loader: 'jsx',
-            jsx: 'automatic',
-          })
-        },
-      },
+      // (transform-react-native-jsx plugin removed — react-native-reanimated
+      //  is now aliased to a web stub at apps/web/src/stubs and expo-blur is
+      //  already aliased to a mock above; no node_modules JSX-in-.js to
+      //  rescue at this stage.)
       portWarningPlugin(isProduction),
       reactPlugin(),
       (isProduction || isStaging) && process.env.DISABLE_EXTRACTION !== '1'
@@ -665,7 +652,8 @@ export default defineConfig(({ mode }) => {
           /\.stories\.[tj]sx?$/,
           /\.mdx$/,
           /expo-clipboard\/build\/ClipboardPasteButton\.js/,
-          /react-native-reanimated/,
+          // react-native-reanimated removed: aliased to a web stub in
+          // apps/web/src/stubs/react-native-reanimated.ts above.
           // When the private package is not installed, externalize it so Rollup doesn't error.
           // Dynamic imports of this module will fail at runtime (caught by loadPrivyPbModule's try/catch).
           ...(!privyPackageInstalled ? [/^@luxamm\/client-privy-embedded-wallet/] : []),

--- a/config/jest-presets/package.json
+++ b/config/jest-presets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@l.x/jest-preset",
+  "name": "jest-presets",
   "version": "1.0.0",
   "description": "Shared Jest preset for Lux Exchange apps and packages.",
   "license": "GPL-3.0-or-later",

--- a/config/vitest-presets/package.json
+++ b/config/vitest-presets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@l.x/vitest-preset",
+  "name": "vitest-presets",
   "version": "1.0.0",
   "description": "Shared Vitest preset for Lux Exchange apps and packages.",
   "license": "GPL-3.0-or-later",

--- a/pkgs/lx/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
+++ b/pkgs/lx/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
@@ -113,8 +113,12 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
   }, [swapConfig, transactionSettings, instructionService, decorateWithEVMLogging])
 
   const lxOrderSwapTxInfoService = useMemo(() => {
-    return createLXSwapTxAndGasInfoService()
-  }, [])
+    return createLXSwapTxAndGasInfoService({
+      ...swapConfig,
+      transactionSettings,
+      instructionService,
+    })
+  }, [swapConfig, transactionSettings, instructionService])
 
   const chainedSwapTxInfoService = useMemo(() => {
     return createChainedActionSwapTxAndGasInfoService({

--- a/pkgs/lx/src/features/transactions/swap/review/services/swapTxAndGasInfoService/lx/lxOrderSwapTxAndGasInfoService.ts
+++ b/pkgs/lx/src/features/transactions/swap/review/services/swapTxAndGasInfoService/lx/lxOrderSwapTxAndGasInfoService.ts
@@ -1,5 +1,5 @@
-import { createClassicSwapTxAndGasInfoService } from '../classic/classicSwapTxAndGasInfoService'
-
-// LX order swap service — delegates to classic swap for now
-// TODO: implement LX-specific order flow when LX order protocol is deployed
-export const createLXSwapTxAndGasInfoService = createClassicSwapTxAndGasInfoService
+// LX order swap service — delegates to classic for execution + gas, with
+// the same ctx (gasStrategy / transactionSettings / instructionService) the
+// other service factories receive. Fixes a no-args invocation crash at the
+// consumer site (hooks.ts) that bubbled into React error #185.
+export { createClassicSwapTxAndGasInfoService as createLXSwapTxAndGasInfoService } from '@l.x/lx/src/features/transactions/swap/review/services/swapTxAndGasInfoService/classic/classicSwapTxAndGasInfoService'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,12 @@ packages:
 
 catalog:
   react-native: "npm:@hanzogui/react-native@0.79.5-fork.1"
-  react-native-reanimated: "npm:@hanzogui/react-native-reanimated@3.19.3-fork.1"
+  # react-native-reanimated: web aliases to apps/web/src/stubs (Vite),
+  # mobile resolves to upstream react-native-reanimated@3.19.3 directly.
+  # The previous @hanzogui/react-native-reanimated@3.19.3-fork.1 was
+  # off-spec semver and shipped raw JSX in lib/module/**/*.js — Rollup's
+  # commonjs-resolver couldn't parse it.
+  react-native-reanimated: "3.19.3"
   react-native-sortables: "npm:@hanzogui/react-native-sortables@1.7.1-fork.1"
   react-native-svg: "npm:@hanzogui/react-native-svg@15.13.0-fork.1"
   "@react-native/gradle-plugin": "npm:@hanzogui/react-native-gradle-plugin@0.79.5-fork.1"


### PR DESCRIPTION
Six fixes for white-label web builds. Result: liquidityio/swap and zooai/exchange can drop their Dockerfile sed-wrapper stack.

1. Kill @hanzogui/react-native-reanimated@3.19.3-fork.1 (off-spec semver, shipped raw JSX in lib/.js). Web aliases to tiny TS stub. Mobile uses upstream 3.19.3.
2. Workspace name mismatches: vitest-presets/jest-presets declared @l.x/{vitest,jest}-preset. pnpm strict-resolves → fail. Renamed.
3. createLXSwapTxAndGasInfoService re-exported from Classic but invoked with no args at hooks.ts:116 → React #185. Fix consumer to pass ctx.
4. api-exchange.lux.network → dex.lux.network/v1/graphql (live Lux Gateway). White-labels override via env.
5. insights.hanzo.ai removed as default. Insights fully opt-in via REACT_APP_INSIGHTS_*.