### PR TITLE
fix(presets): scope rename — @l.x/vitest-preset + @l.x/jest-preset on both sides

### DIFF
--- a/config/jest-presets/package.json
+++ b/config/jest-presets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jest-presets",
+  "name": "@l.x/jest-preset",
   "version": "1.0.0",
   "description": "Shared Jest preset for Lux Exchange apps and packages.",
   "license": "GPL-3.0-or-later",

--- a/config/vitest-presets/package.json
+++ b/config/vitest-presets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vitest-presets",
+  "name": "@l.x/vitest-preset",
   "version": "1.0.0",
   "description": "Shared Vitest preset for Lux Exchange apps and packages.",
   "license": "GPL-3.0-or-later",

--- a/pkgs/lx/package.json
+++ b/pkgs/lx/package.json
@@ -156,7 +156,7 @@
     "typechain": "5.2.0",
     "typescript": "5.9.3",
     "vitest": "3.2.1",
-    "vitest-presets": "^1.0.0"
+    "@l.x/vitest-preset": "^1.0.0"
   },
   "main": "src/index.ts",
   "private": false,

--- a/pkgs/ui/package.json
+++ b/pkgs/ui/package.json
@@ -66,7 +66,7 @@
     "typescript": "5.9.3",
     "uppercamelcase": "3.0.0",
     "vitest": "3.2.1",
-    "vitest-presets": "^1.0.0"
+    "@l.x/vitest-preset": "^1.0.0"
   },
   "files": [
     "src",

--- a/pkgs/utilities/package.json
+++ b/pkgs/utilities/package.json
@@ -53,7 +53,7 @@
     "eslint": "8.57.1",
     "typescript": "5.9.3",
     "vitest": "3.2.1",
-    "vitest-presets": "^1.0.0"
+    "@l.x/vitest-preset": "^1.0.0"
   },
   "main": "src/index.ts",
   "private": false,

--- a/pkgs/wallet/package.json
+++ b/pkgs/wallet/package.json
@@ -87,7 +87,7 @@
     "jest": "29.7.0",
     "jest-chrome": "0.8.0",
     "jest-extended": "4.0.2",
-    "jest-presets": "^1.0.0",
+    "@l.x/jest-preset": "^1.0.0",
     "react-test-renderer": "19.0.3",
     "typescript": "5.9.3"
   },


### PR DESCRIPTION
PR#24 left the presets unscoped. Combined with the workspace:^→pinned-semver sweep, pnpm fetched 'vitest-presets' from npm and 404'd. Scope BOTH the package names AND the 4 references consistently so workspace lookup matches.