### PR TITLE
fix(tracing): add missing setupInsights import

### DIFF
--- a/apps/web/src/tracing/index.ts
+++ b/apps/web/src/tracing/index.ts
@@ -1,4 +1,5 @@
 import { setupAmplitude } from '~/tracing/amplitude'
+import { setupInsights } from '~/tracing/insights'
 import { isRemoteReportingEnabled } from '~/utils/env'
 
 if (isRemoteReportingEnabled()) {


### PR DESCRIPTION
Bundle threw 'setupInsights is not defined' at runtime — index.ts called the function but never imported it. Blocked SPA hydration on every white-label.