### PR TITLE
fix(web): runtime-resolve @hanzo/insights + 32x32 favicon

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,9 @@
     <title>Uniswap Interface</title>
 
     <!-- Vite uses / for public assets instead of %PUBLIC_URL% -->
-    <link rel="shortcut icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any" />
+    <link rel="icon" type="image/png" href="/favicon.png" sizes="32x32" />
+    <link rel="shortcut icon" href="/favicon.png" />
     <link rel="apple-touch-icon" sizes="192x192" href="/images/192x192_App_Icon.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="/images/512x512_App_Icon.png" />
 

--- a/apps/web/src/tracing/insights.ts
+++ b/apps/web/src/tracing/insights.ts
@@ -2,11 +2,6 @@ import { brand } from '@l.x/config'
 import { isTestEnv } from '@l.x/utils/src/environment/env'
 import { logger } from '@l.x/utils/src/logger/logger'
 
-// Insights is fully opt-in via env. No hardcoded API key or host —
-// white-label builds (liquidity, zoo) self-host their own insights and
-// supply their own keys; the canonical Lux build supplies its own.
-// When unset, setupInsights becomes a no-op so we never leak telemetry
-// to a host the consuming brand didn't configure.
 const INSIGHTS_API_KEY = process.env.REACT_APP_INSIGHTS_API_KEY || ''
 const INSIGHTS_HOST = process.env.REACT_APP_INSIGHTS_HOST || ''
 
@@ -28,7 +23,13 @@ export async function setupInsights() {
   }
 
   try {
-    const { default: Insights } = await import('@hanzo/insights')
+    const pkg = '@hanzo/insights'
+    const mod: any = await import(/* @vite-ignore */ pkg).catch(() => null)
+    if (!mod) {
+      logger.debug('insights.ts', 'setupInsights', '@hanzo/insights not installed — skipping')
+      return
+    }
+    const Insights = mod.default ?? mod
     const appSlug = brand.appDomain?.replace(/\./g, '-') || 'lux-exchange'
     insightsClient = new Insights(INSIGHTS_API_KEY, {
       api_host: INSIGHTS_HOST,
@@ -36,15 +37,13 @@ export async function setupInsights() {
       capture_pageleave: true,
       autocapture: true,
       persistence: 'localStorage',
-      loaded: (insights) => {
+      loaded: (insights: any) => {
         logger.debug('insights.ts', 'setupInsights', 'Hanzo Insights initialized')
-        // Identify the app
         insights.register({
           app: appSlug,
           app_version: process.env.REACT_APP_GIT_COMMIT_HASH || 'unknown',
           platform: 'web',
         })
-        // Expose capture globally so pkgs/lx telemetry can forward events
         ;(window as any).__INSIGHTS = insights
       },
     })


### PR DESCRIPTION
Indirect specifier so rolldown treats @hanzo/insights as runtime resolution; gracefully no-op when not installed. Plus declare SVG favicon + 32x32 PNG fallback so tabs render intended size.