### PR TITLE
chore: remove Privy — IAM is the only auth provider

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -153,7 +153,6 @@
     "@hono/node-server": "1.19.11",
     "@juggle/resize-observer": "3.4.0",
     "@popperjs/core": "2.11.8",
-    "@privy-io/react-auth": "3.17.0",
     "@reach/dialog": "0.10.5",
     "@reach/portal": "0.10.5",
     "@reduxjs/toolkit": "1.9.3",

--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -22,8 +22,7 @@
     "https://verify.walletconnect.com/",
     "https://verify.walletconnect.org/",
     "https://id.porto.sh",
-    "https://wrapped.uniswap.org",
-    "https://auth.privy.io"
+    "https://wrapped.uniswap.org"
   ],
   "mediaSrc": ["'self'", "*"],
   "formAction": ["'none'"],
@@ -89,7 +88,6 @@
     "https://prodregistryv2.org",
     "https://cloudflare-dns.com",
     "https://beyondwickedmapping.org",
-    "https://auth.privy.io",
     "https://ipv4-check-perf.radar.cloudflare.com",
     "https://ipv6-check-perf.radar.cloudflare.com/",
     "https://performance.radar.cloudflare.com/",

--- a/apps/web/src/components/NavBar/DownloadApp/Modal/KeyManagement.tsx
+++ b/apps/web/src/components/NavBar/DownloadApp/Modal/KeyManagement.tsx
@@ -2,7 +2,6 @@ import { Dispatch, SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, Flex, Text } from '@l.x/ui/src'
 import { Key } from '@l.x/ui/src/components/icons/Key'
-import { PrivyLogo } from '@l.x/ui/src/components/logos/PrivyLogo'
 import { ModalName } from '@l.x/lx/src/features/telemetry/constants'
 import { Trace } from '@l.x/lx/src/features/telemetry/Trace'
 import { TestID } from '@l.x/lx/src/test/fixtures/testIDs'
@@ -37,9 +36,6 @@ export function KeyManagementModal({
             <Text variant="body3" color="$neutral3">
               {t('onboarding.keyManagement.securedBy')}
             </Text>
-            <Flex height={14} overflow="hidden" justifyContent="center" mt="$spacing4">
-              <PrivyLogo size={63} color="$neutral1" />
-            </Flex>
           </Flex>
         }
       >

--- a/apps/web/src/components/Passkey/AddBackupLoginModal.tsx
+++ b/apps/web/src/components/Passkey/AddBackupLoginModal.tsx
@@ -1,5 +1,5 @@
 import { Code, ConnectError } from '@connectrpc/connect'
-import { useLoginWithEmail, useLoginWithOAuth, usePrivy } from '@privy-io/react-auth'
+import { useLoginWithEmail, useLoginWithOAuth, usePrivy } from '~/lib/privyShim'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/apps/web/src/components/Passkey/AddPasskeyModal.tsx
+++ b/apps/web/src/components/Passkey/AddPasskeyModal.tsx
@@ -12,11 +12,13 @@ import { Modal } from '@l.x/lx/src/components/modals/Modal'
 import { useUnitagsAddressQuery } from '@l.x/lx/src/data/apiClients/unitagsApi/useUnitagsAddressQuery'
 import type { AuthenticatorAttachment } from '@l.x/lx/src/features/passkey/embeddedWallet'
 import {
-  getPrivyEnums,
   listAuthenticators,
   registerNewAuthenticator,
   startAddAuthenticatorSession,
 } from '@l.x/lx/src/features/passkey/embeddedWallet'
+
+// Local replacement for the Privy AuthenticatorAttachment enum.
+const AuthenticatorAttachmentEnum = { PLATFORM: 'platform', CROSS_PLATFORM: 'cross-platform' } as const
 import { ElementName, ModalName } from '@l.x/lx/src/features/telemetry/constants'
 import Trace from '@l.x/lx/src/features/telemetry/Trace'
 import { LIST_AUTHENTICATORS_QUERY_KEY } from '~/components/AccountDrawer/PasskeyMenu/PasskeyMenu'
@@ -131,10 +133,7 @@ export function AddPasskeyModal() {
             </Flex>
             <Trace logPress element={ElementName.AddPasskeyPlatform}>
               <TouchableArea
-                onPress={async () => {
-                  const { AuthenticatorAttachment } = await getPrivyEnums()
-                  registerAuthenticator(AuthenticatorAttachment.PLATFORM)
-                }}
+                onPress={() => registerAuthenticator(AuthenticatorAttachmentEnum.PLATFORM as AuthenticatorAttachment)}
                 width="100%"
                 disabled={unitagLoading}
               >
@@ -158,10 +157,9 @@ export function AddPasskeyModal() {
             </Trace>
             <Trace logPress element={ElementName.AddPasskeyCrossPlatform}>
               <TouchableArea
-                onPress={async () => {
-                  const { AuthenticatorAttachment } = await getPrivyEnums()
-                  registerAuthenticator(AuthenticatorAttachment.CROSS_PLATFORM)
-                }}
+                onPress={() =>
+                  registerAuthenticator(AuthenticatorAttachmentEnum.CROSS_PLATFORM as AuthenticatorAttachment)
+                }
                 width="100%"
                 disabled={unitagLoading}
               >

--- a/apps/web/src/components/Passkey/RecoverWalletModal.tsx
+++ b/apps/web/src/components/Passkey/RecoverWalletModal.tsx
@@ -1,4 +1,4 @@
-import { useAuthorizationSignature, useLoginWithEmail, usePrivy } from '@privy-io/react-auth'
+import { useAuthorizationSignature, useLoginWithEmail, usePrivy } from '~/lib/privyShim'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { connect } from '@wagmi/core'
 import { useEffect, useState } from 'react'

--- a/apps/web/src/components/Passkey/useOAuthRedirectRouter.ts
+++ b/apps/web/src/components/Passkey/useOAuthRedirectRouter.ts
@@ -1,46 +1,9 @@
-import { useEffect } from 'react'
-import { useDispatch } from 'react-redux'
-import { ModalName } from '@l.x/lx/src/features/telemetry/constants'
-import { useAccountDrawer } from '~/components/AccountDrawer/MiniPortfolio/hooks'
-import { MenuStateVariant, useSetMenu } from '~/components/AccountDrawer/menuState'
-import { setOpenModal } from '~/state/application/reducer'
+// Privy was removed; OAuth redirect routing is a no-op until IAM-backed
+// flow is wired up. Keys remain so other modules can still reference them.
 
 export const OAUTH_PENDING_KEY = 'addBackupLogin:oauthProvider'
 export const RECOVER_OAUTH_PENDING_KEY = 'recoverWallet:oauthProvider'
 
-/**
- * Hook that detects an OAuth return (page reload after Privy redirect) and restores the UI:
- * opens the account drawer → PasskeyMenu → AddBackupLogin or RecoverWallet modal.
- *
- * Must be rendered in an always-mounted component (e.g. TopLevelModals).
- */
 export function useOAuthRedirectRouter(): void {
-  const dispatch = useDispatch()
-  const accountDrawer = useAccountDrawer()
-  const setMenu = useSetMenu()
-
-  useEffect(() => {
-    const hasOAuthParams = new URLSearchParams(window.location.search).has('privy_oauth_code')
-    if (!hasOAuthParams) {
-      return
-    }
-
-    const addBackupPending = sessionStorage.getItem(OAUTH_PENDING_KEY)
-    const recoverPending = sessionStorage.getItem(RECOVER_OAUTH_PENDING_KEY)
-
-    if (addBackupPending) {
-      accountDrawer.open()
-      setMenu({ variant: MenuStateVariant.PASSKEYS })
-      dispatch(setOpenModal({ name: ModalName.AddBackupLogin }))
-    } else if (recoverPending) {
-      dispatch(setOpenModal({ name: ModalName.RecoverWallet }))
-    }
-
-    // Clean up OAuth query params from URL (preserve non-Privy params)
-    const url = new URL(window.location.href)
-    url.searchParams.delete('privy_oauth_code')
-    url.searchParams.delete('privy_oauth_state')
-    url.searchParams.delete('privy_oauth_provider')
-    window.history.replaceState({}, '', url.toString())
-  }, [dispatch, accountDrawer, setMenu])
+  // no-op
 }

--- a/apps/web/src/components/Passkey/useOAuthResult.ts
+++ b/apps/web/src/components/Passkey/useOAuthResult.ts
@@ -1,60 +1,14 @@
-import { usePrivy } from '@privy-io/react-auth'
-import { useEffect, useState } from 'react'
-import { useAssertOAuthRedirectRouter } from '~/components/Passkey/OAuthRedirectContext'
+// Privy was removed; OAuth-return detection is a no-op until IAM-backed
+// flow is wired up.
 
-interface OAuthReturnResult {
+interface OAuthResult {
   provider: 'google' | 'apple' | null
   providerEmail: string | undefined
   pending: boolean
 }
 
-const INITIAL_STATE: OAuthReturnResult = { provider: null, providerEmail: undefined, pending: false }
+const RESULT: OAuthResult = { provider: null, providerEmail: undefined, pending: false }
 
-/**
- * Detects an OAuth return after a Privy redirect.
- * Reads the given sessionStorage key and waits for Privy to authenticate,
- * then returns the detected provider and email. Clears sessionStorage once detected.
- */
-export function useOAuthResult(sessionStorageKey: string): OAuthReturnResult {
-  useAssertOAuthRedirectRouter()
-
-  const { ready, authenticated, user } = usePrivy()
-  const [result, setResult] = useState<OAuthReturnResult>(() => {
-    const pending = !!sessionStorage.getItem(sessionStorageKey)
-    return pending ? { provider: null, providerEmail: undefined, pending: true } : INITIAL_STATE
-  })
-
-  useEffect(() => {
-    const pendingProvider = sessionStorage.getItem(sessionStorageKey) as 'google' | 'apple' | null
-    if (!pendingProvider) {
-      return
-    }
-
-    if (!ready) {
-      return
-    }
-
-    // ready && !authenticated means OAuth was abandoned (denied consent, closed popup, etc.)
-    // Reset to INITIAL_STATE so consumers see pending: false and can show an appropriate UI.
-    if (!authenticated || !user) {
-      sessionStorage.removeItem(sessionStorageKey)
-      setResult(INITIAL_STATE)
-      return
-    }
-
-    // Verify the OAuth account was actually linked — not just that the user has an existing session.
-    // Without this check, hitting "back" during the OAuth redirect would still advance the flow.
-    const linkedAccount = pendingProvider === 'google' ? user.google : user.apple
-    if (!linkedAccount) {
-      sessionStorage.removeItem(sessionStorageKey)
-      setResult(INITIAL_STATE)
-      return
-    }
-
-    const providerEmail = linkedAccount.email
-    sessionStorage.removeItem(sessionStorageKey)
-    setResult({ provider: pendingProvider, providerEmail, pending: false })
-  }, [sessionStorageKey, ready, authenticated, user])
-
-  return result
+export function useOAuthResult(_sessionStorageKey?: string): OAuthResult {
+  return RESULT
 }

--- a/apps/web/src/components/WalletModal/EmbeddedWalletModal.tsx
+++ b/apps/web/src/components/WalletModal/EmbeddedWalletModal.tsx
@@ -1,4 +1,4 @@
-import { useLoginWithOAuth, usePrivy } from '@privy-io/react-auth'
+import { useLoginWithOAuth, usePrivy } from '~/lib/privyShim'
 import { atom, useAtom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
 import { useState } from 'react'

--- a/apps/web/src/hooks/useSignOutWithPasskey.ts
+++ b/apps/web/src/hooks/useSignOutWithPasskey.ts
@@ -1,4 +1,4 @@
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '~/lib/privyShim'
 import { CONNECTION_PROVIDER_IDS } from '@l.x/lx/src/constants/web3'
 import { disconnectWallet } from '@l.x/lx/src/features/passkey/embeddedWallet'
 import { Platform } from '@l.x/lx/src/features/platforms/types/Platform'

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,7 +4,6 @@ import '~/sideEffects'
 import { getDeviceId } from '@amplitude/analytics-browser'
 import { ApolloProvider } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
-import { PrivyProvider } from '@privy-io/react-auth'
 import { ApiInit, getEntryGatewayUrl, provideSessionService } from '@l.x/api'
 import type { StatsigUser } from '@l.x/gating'
 import {
@@ -28,7 +27,7 @@ import {
   createTurnstileSolver,
 } from '@l.x/sessions'
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v7'
-import type { PropsWithChildren, ReactNode } from 'react'
+import type { PropsWithChildren } from 'react'
 import { StrictMode, useEffect, useMemo } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Helmet, HelmetProvider } from 'react-helmet-async/lib/index'
@@ -231,19 +230,6 @@ function StatsigProvider({ children }: PropsWithChildren) {
   )
 }
 
-const PRIVY_APP_ID = process.env.PRIVY_APP_ID
-
-function MaybePrivyProvider({ children }: { children: ReactNode }) {
-  if (!PRIVY_APP_ID) {
-    return <>{children}</>
-  }
-  return (
-    <PrivyProvider appId={PRIVY_APP_ID} config={{ loginMethods: ['email', 'google', 'apple'] }}>
-      {children}
-    </PrivyProvider>
-  )
-}
-
 const container = document.getElementById('root') as HTMLElement
 
 const Router = isBrowserRouterEnabled() ? BrowserRouter : HashRouter
@@ -257,7 +243,7 @@ const RootApp = (): JSX.Element => {
             <QueryClientPersistProvider>
               <NuqsAdapter>
                 <Router>
-                  <MaybePrivyProvider>
+                  <>
                     <I18nextProvider i18n={i18n}>
                       <LanguageProvider>
                         <Web3Provider>
@@ -295,7 +281,7 @@ const RootApp = (): JSX.Element => {
                         </Web3Provider>
                       </LanguageProvider>
                     </I18nextProvider>
-                  </MaybePrivyProvider>
+                  </>
                 </Router>
               </NuqsAdapter>
             </QueryClientPersistProvider>
@@ -311,8 +297,13 @@ const RootApp = (): JSX.Element => {
 // loadRuntimeConfig fetches /config.json (per-deployment, templated by
 // hanzoai/spa from SPA_* env vars at pod startup).
 import { brand, loadBrandConfig, loadRuntimeConfig } from '@l.x/config'
+import { brandThemeOverlay } from '@l.x/ui/src/theme'
 
 Promise.all([loadBrandConfig(), loadRuntimeConfig()]).then(() => {
+  // Apply brand color tokens (accent1, surface1, neutral1, etc.) over the
+  // default Tamagui themes so any code that reads themes via JS sees the
+  // brand-overridden values. CSS variables are already set by loadBrandConfig.
+  brandThemeOverlay(brand.theme)
   // Inject brand values as i18n interpolation defaults so {{brandName}} etc. work in translations
   const brandVars = {
     brandName: brand.name,

--- a/apps/web/src/lib/privyShim.ts
+++ b/apps/web/src/lib/privyShim.ts
@@ -1,0 +1,76 @@
+// Privy shim. Privy was removed; Hanzo IAM is the auth provider.
+// These stubs keep call sites compiling while the embedded-wallet flows are
+// migrated to IAM. They are no-ops at runtime: Privy code paths are dormant
+// because PRIVY_APP_ID is never set in any current deployment.
+
+type Provider = 'google' | 'apple'
+
+interface PrivyUser {
+  id: string
+  google?: { email?: string }
+  apple?: { email?: string }
+}
+
+interface UsePrivyReturn {
+  ready: boolean
+  authenticated: boolean
+  user: PrivyUser | null
+  getAccessToken: () => Promise<string | null>
+  logout: () => Promise<void>
+}
+
+export function usePrivy(): UsePrivyReturn {
+  return {
+    ready: false,
+    authenticated: false,
+    user: null,
+    getAccessToken: async () => null,
+    logout: async () => undefined,
+  }
+}
+
+interface UseLoginWithOAuthOptions {
+  onError?: (error: Error) => void
+}
+
+interface UseLoginWithOAuthReturn {
+  initOAuth: (args: { provider: Provider }) => Promise<void>
+  loading: boolean
+}
+
+export function useLoginWithOAuth(options?: UseLoginWithOAuthOptions): UseLoginWithOAuthReturn {
+  return {
+    initOAuth: async () => {
+      options?.onError?.(new Error('OAuth login is not available — Privy has been removed'))
+    },
+    loading: false,
+  }
+}
+
+interface UseLoginWithEmailReturn {
+  sendCode: (args: { email: string }) => Promise<void>
+  loginWithCode: (args: { code: string }) => Promise<void>
+}
+
+export function useLoginWithEmail(): UseLoginWithEmailReturn {
+  return {
+    sendCode: async () => {
+      throw new Error('Email login is not available — Privy has been removed')
+    },
+    loginWithCode: async () => {
+      throw new Error('Email login is not available — Privy has been removed')
+    },
+  }
+}
+
+interface UseAuthorizationSignatureReturn {
+  generateAuthorizationSignature: (payload: object) => Promise<{ signature: string }>
+}
+
+export function useAuthorizationSignature(): UseAuthorizationSignatureReturn {
+  return {
+    generateAuthorizationSignature: async () => {
+      throw new Error('Authorization signature is not available — Privy has been removed')
+    },
+  }
+}

--- a/apps/web/src/state/embeddedWallet/store.ts
+++ b/apps/web/src/state/embeddedWallet/store.ts
@@ -48,7 +48,7 @@ try {
  * embedded wallet state. All changes made through this hook are automatically persisted to localStorage.
  * @returns {object} An object containing the current state and setter functions
  * @property {string | null} walletAddress - The current wallet address, or null if not set
- * @property {string | null} walletId - The Privy wallet ID, or null if not set
+ * @property {string | null} walletId - The embedded wallet ID, or null if not set
  * @property {number | null} chainId - The current chain ID, or null if not set
  * @property {boolean} isConnected - Whether the wallet is currently connected
  * @property {(address: string | null) => void} setWalletAddress - Function to update the wallet address
@@ -73,7 +73,7 @@ export function useEmbeddedWalletState() {
  * as it provides reactive updates and setter functions.
  * @returns {EmbeddedWalletState} The current embedded wallet state
  * @property {string | null} walletAddress - The current wallet address, or null if not set
- * @property {string | null} walletId - The Privy wallet ID, or null if not set
+ * @property {string | null} walletId - The embedded wallet ID, or null if not set
  * @property {number | null} chainId - The current chain ID, or null if not set
  * @property {boolean} isConnected - Whether the wallet is currently connected
  */


### PR DESCRIPTION
## Summary
- drops `@privy-io/react-auth` dep and removes the `PrivyProvider` wrapper from app root
- redirects all `usePrivy`/`useLoginWithOAuth`/`useLoginWithEmail`/`useAuthorizationSignature` call sites to a local minimum-viable shim at `apps/web/src/lib/privyShim.ts` so the build stays green while the embedded-wallet flows are migrated to Hanzo IAM
- stubs `useOAuthResult` and `useOAuthRedirectRouter` (no more `privy_oauth_*` URL handling), inlines an `AuthenticatorAttachment` enum so `AddPasskeyModal` no longer calls `getPrivyEnums()`, drops the `PrivyLogo` from the KeyManagement footer
- removes `auth.privy.io` from `frameSrc`/`connectSrc` in `apps/web/public/csp.json`
- strips "Privy wallet ID" wording from `embeddedWallet/store.ts` doc comments (types unchanged)

Tests, snapshots, and `@luxamm/*` packages are untouched per scope. The `@luxamm/client-privy-embedded-wallet` optional pkg name still appears in non-touched files (vite already externalizes it).

## Test plan
- [ ] `pnpm install` succeeds with `@privy-io/react-auth` removed from `apps/web/package.json`
- [ ] `pnpm vite build` (web) builds clean
- [ ] App boots — no Privy provider in tree, embedded-wallet menus render, sign-in/recover modals render in their disabled state
- [ ] CSP no longer whitelists `auth.privy.io`