### PR TITLE
fix(brand): white-label theme tokens, contrast, NavIcon size

### DIFF
--- a/apps/web/src/components/Logo/NavIcon.tsx
+++ b/apps/web/src/components/Logo/NavIcon.tsx
@@ -11,8 +11,8 @@ export function NavIcon({ onClick }: { onClick?: () => void }) {
     <img
       src={src}
       alt={alt}
-      width={28}
-      height={28}
+      width={40}
+      height={40}
       onClick={onClick}
       style={{ cursor: onClick ? 'pointer' : undefined, display: 'block' }}
     />

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -304,6 +304,7 @@ Promise.all([loadBrandConfig(), loadRuntimeConfig()]).then(() => {
   // default Tamagui themes so any code that reads themes via JS sees the
   // brand-overridden values. CSS variables are already set by loadBrandConfig.
   brandThemeOverlay(brand.theme)
+
   // Inject brand values as i18n interpolation defaults so {{brandName}} etc. work in translations
   const brandVars = {
     brandName: brand.name,

--- a/pkgs/lx/src/components/CurrencyInputPanel/SelectTokenButton.tsx
+++ b/pkgs/lx/src/components/CurrencyInputPanel/SelectTokenButton.tsx
@@ -28,7 +28,7 @@ export const SelectTokenButton = memo(function _SelectTokenButton({
   const validTokenColor = validColor(tokenColor)
   const hoverStyle: { backgroundColor: ComponentProps<typeof Flex>['backgroundColor'] } = useMemo(
     () => ({
-      backgroundColor: selectedCurrencyInfo ? '$surface1Hovered' : (validTokenColor ?? '$accent1Hovered'),
+      backgroundColor: selectedCurrencyInfo ? '$surface1Hovered' : (validTokenColor ?? '$surface2Hovered'),
       filter: validTokenColor ? getHoverCssFilter({ isDarkMode }) : undefined,
     }),
     [selectedCurrencyInfo, validTokenColor, isDarkMode],
@@ -47,12 +47,19 @@ export const SelectTokenButton = memo(function _SelectTokenButton({
     )
   }
 
-  const textColor = selectedCurrencyInfo ? '$neutral1' : tokenColor ? getContrastPassingTextColor(tokenColor) : '$white'
+  // When no token is selected, render as a neutral surface pill so the label is
+  // always readable regardless of the brand's accent1 (which can be white,
+  // yellow, or any low-contrast color in white-label deployments).
+  const textColor = selectedCurrencyInfo
+    ? '$neutral1'
+    : tokenColor
+      ? getContrastPassingTextColor(tokenColor)
+      : '$neutral1'
   const chevronColor = selectedCurrencyInfo ? '$neutral2' : textColor
 
   return (
     <TouchableArea
-      backgroundColor={selectedCurrencyInfo ? '$surface1' : (validTokenColor ?? '$accent1')}
+      backgroundColor={selectedCurrencyInfo ? '$surface1' : (validTokenColor ?? '$surface2')}
       borderRadius="$roundedFull"
       testID={testID}
       borderColor="$surface3Solid"

--- a/pkgs/ui/src/theme/brandThemeOverlay.ts
+++ b/pkgs/ui/src/theme/brandThemeOverlay.ts
@@ -1,0 +1,95 @@
+/**
+ * Brand theme overlay — merges `brand.theme.{light,dark}` color overrides over
+ * the default Tamagui theme tokens at runtime.
+ *
+ * Why this exists:
+ * - The default themes ship with hard-coded accent/surface/neutral colors
+ *   (`pkgs/ui/src/theme/themes.ts`). White-label deployments need these to
+ *   come from `brand.theme` in the runtime config.
+ * - On web, Tamagui themes also compile down to CSS custom properties; brand.ts
+ *   already overrides `--accent1`, `--surface1`, etc. on `document.documentElement`.
+ *   This helper covers the JS path so any code that reads theme tokens directly
+ *   (useSporeColors, useTheme, etc.) sees the brand values too.
+ *
+ * Call once after `loadBrandConfig()` resolves and before Tamagui mounts.
+ */
+import { themes } from '@l.x/ui/src/theme/themes'
+
+// Local copy of the BrandTheme shape to avoid a runtime dependency on @l.x/config
+// (which itself does not depend on @l.x/ui — keep it that way).
+export interface BrandTheme {
+  accent1?: string
+  accent1Hovered?: string
+  accent2?: string
+  accent3?: string
+  surface1?: string
+  surface2?: string
+  surface3?: string
+  neutral1?: string
+  neutral2?: string
+  neutral3?: string
+  neutralContrast?: string
+  background?: string
+  statusSuccess?: string
+  statusCritical?: string
+  statusWarning?: string
+  scrim?: string
+}
+
+const TOKEN_KEYS = [
+  'accent1',
+  'accent1Hovered',
+  'accent2',
+  'accent3',
+  'surface1',
+  'surface2',
+  'surface3',
+  'neutral1',
+  'neutral2',
+  'neutral3',
+  'statusSuccess',
+  'statusCritical',
+  'statusWarning',
+  'scrim',
+] as const satisfies readonly (keyof BrandTheme)[]
+
+function overlayTheme(target: Record<string, unknown>, overrides?: BrandTheme): void {
+  if (!overrides) {
+    return
+  }
+  for (const key of TOKEN_KEYS) {
+    const value = overrides[key]
+    if (typeof value === 'string' && value.length > 0) {
+      target[key] = value
+    }
+  }
+  // Derived: page background falls back to surface1
+  const bg = overrides.background ?? overrides.surface1
+  if (bg) {
+    target['background'] = bg
+  }
+  // Derived: hover/press/focus follow surface2 unless explicitly set
+  const bgHover = overrides.surface2
+  if (bgHover) {
+    target['backgroundHover'] = bgHover
+    target['backgroundPress'] = bgHover
+    target['backgroundFocus'] = bgHover
+  }
+  // Color tokens (Tamagui's `color` etc.) follow neutral1/accent1
+  if (overrides.neutral1) {
+    target['color'] = overrides.neutral1
+  }
+  if (overrides.accent1) {
+    target['colorHover'] = overrides.accent1
+    target['colorPress'] = overrides.accent1
+    target['colorFocus'] = overrides.accent1
+  }
+}
+
+export function brandThemeOverlay(theme?: { light?: BrandTheme; dark?: BrandTheme }): void {
+  if (!theme) {
+    return
+  }
+  overlayTheme(themes.light as Record<string, unknown>, theme.light)
+  overlayTheme(themes.dark as Record<string, unknown>, theme.dark)
+}

--- a/pkgs/ui/src/theme/index.ts
+++ b/pkgs/ui/src/theme/index.ts
@@ -1,4 +1,5 @@
 export * from './borderRadii'
+export * from './brandThemeOverlay'
 export * from './breakpoints'
 export * from './color'
 export * from './fonts'


### PR DESCRIPTION
## Summary
- Add `brandThemeOverlay()` helper in `@l.x/ui` that merges `brand.theme.{light,dark}` over the default Tamagui theme tokens (`accent1`, `surface1`, `neutral1`, etc.). Called from `apps/web/src/index.tsx` after `loadBrandConfig()` so JS reads of theme tokens reflect brand overrides. CSS variables were already set on `documentElement` in `brand.ts`.
- Fix white-on-white "Choose token" pill in the swap widget: the placeholder rendered `\$accent1` background with `\$white` text. When a brand sets `accent1: #FFFFFF` (Lux dark theme default), the label disappeared. Switch placeholder background to `\$surface2` and text to `\$neutral1` so the label stays readable on every brand.
- Bump `NavIcon` from 28×28 to 40×40 for legibility.

Favicon SVG-first ordering and TokenCloud chain-permissive rendering were already correct in main (PRs #28, #32).

## Test plan
- [ ] Lux brand: swap pill renders neutral surface2 with readable label
- [ ] Zoo brand: brand accent flows through to buttons/links via CSS vars + JS theme reads
- [ ] NavIcon visibly larger in nav bar