### PR TITLE
fix: pin @luxdex/sdk to prebuilt-dist commit

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -183,7 +183,7 @@
     "@luxamm/router-sdk": "2.7.5",
     "@luxamm/sdk-core": "7.12.4",
     "@luxamm/token-lists": "1.0.3",
-    "@luxdex/sdk": "github:lux-dex/sdk#e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0",
+    "@luxdex/sdk": "github:lux-dex/sdk#7d3a0916ecd5f949f4a67ae7af5e7f545800c408",
     "@luxamm/universal-router-sdk": "4.33.5",
     "@luxamm/v2-sdk": "4.19.5",
     "@luxamm/v3-core": "1.0.104",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
         specifier: 1.29.5
         version: 1.29.5(hardhat@2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@25.5.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@luxdex/sdk':
-        specifier: github:lux-dex/sdk#e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0
-        version: https://codeload.github.com/lux-dex/sdk/tar.gz/e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        specifier: github:lux-dex/sdk#7d3a0916ecd5f949f4a67ae7af5e7f545800c408
+        version: https://codeload.github.com/lux-dex/sdk/tar.gz/7d3a0916ecd5f949f4a67ae7af5e7f545800c408(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -8000,8 +8000,8 @@ packages:
     resolution: {integrity: sha512-7bjKuWXsaIYYJtnqI896gNc097Q5MvMWhS31RTaLxHxeMroycBwojr3nQuQ3zoyIPbRNofQYg9AMNy/aZ6ziXA==}
     engines: {node: '>=14'}
 
-  '@luxdex/sdk@https://codeload.github.com/lux-dex/sdk/tar.gz/e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0':
-    resolution: {tarball: https://codeload.github.com/lux-dex/sdk/tar.gz/e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0}
+  '@luxdex/sdk@https://codeload.github.com/lux-dex/sdk/tar.gz/7d3a0916ecd5f949f4a67ae7af5e7f545800c408':
+    resolution: {tarball: https://codeload.github.com/lux-dex/sdk/tar.gz/7d3a0916ecd5f949f4a67ae7af5e7f545800c408}
     version: 1.0.0
     engines: {node: '>=10'}
 
@@ -40950,7 +40950,7 @@ snapshots:
     transitivePeerDependencies:
       - hardhat
 
-  '@luxdex/sdk@https://codeload.github.com/lux-dex/sdk/tar.gz/e9578f0c345f6d2c56e4cd2c5148ffd52ce157b0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@luxdex/sdk@https://codeload.github.com/lux-dex/sdk/tar.gz/7d3a0916ecd5f949f4a67ae7af5e7f545800c408(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/providers': 5.7.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)


### PR DESCRIPTION
Bumps to lux-dex/sdk@7d3a091 which ships pre-built dist/ committed into the repo. Required because Dockerfile uses pnpm install --ignore-scripts which skips prepare hook.