### PR TITLE
chore: scrub interface.gateway.uniswap.org → dex.lux.network

### DIFF
--- a/apps/web/functions/client.ts
+++ b/apps/web/functions/client.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client'
 
-const GRAPHQL_ENDPOINT = 'https://interface.gateway.uniswap.org/v1/graphql'
+const GRAPHQL_ENDPOINT = `${process.env.REACT_APP_GATEWAY_HOST || 'https://dex.lux.network'}/v1/graphql`
 
 //TODO: Figure out how to make ApolloClient global variable
 export default new ApolloClient({

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -18,7 +18,7 @@
 
     <!-- CSP will be injected here -->
 
-    <link rel="preconnect" href="https://interface.gateway.uniswap.org/" crossorigin/>
+    <link rel="preconnect" href="https://dex.lux.network/" crossorigin/>
     <link rel="preconnect" href="https://mainnet.infura.io/" crossorigin/>
 
     <link rel="preload" href="/fonts/Basel-Grotesk-Book.woff2" as="font" type="font/woff2" crossorigin />

--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -47,6 +47,7 @@
     "https://*.walletconnect.org",
     "https://api.avax.network/ext/bc/C/rpc",
     "https://api.moonpay.com/",
+    "https://dex.lux.network",
     "https://api.opensea.io",
     "https://bsc-dataseed.bnbchain.org",
     "https://bsc-dataseed1.bnbchain.org",

--- a/apps/web/scripts/generate-sitemap.js
+++ b/apps/web/scripts/generate-sitemap.js
@@ -63,8 +63,9 @@ fs.readFile('./public/tokens-sitemap.xml', 'utf8', async (_err, data) => {
       })
     }
 
+    const GATEWAY_HOST = process.env.REACT_APP_GATEWAY_HOST || 'https://dex.lux.network'
     const tokensResponse = await fetch(
-      'https://interface.gateway.uniswap.org/v2/uniswap.explore.v1.ExploreStatsService/TokenRankings?connect=v1&encoding=json&message=' +
+      `${GATEWAY_HOST}/v2/uniswap.explore.v1.ExploreStatsService/TokenRankings?connect=v1&encoding=json&message=` +
         encodeURIComponent(JSON.stringify({ chainId: 'ALL_NETWORKS' })),
       {
         method: 'GET',


### PR DESCRIPTION
Drops the last 140 console-error CSP violations from white-label builds. Default to env-driven Lux Gateway.