### PR TITLE
feat: $113T liquidity banner + Onboard Now gate for Liquid EVM securities

### DIFF
--- a/apps/web/src/pages/Landing/Fold.tsx
+++ b/apps/web/src/pages/Landing/Fold.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from 'react'
 import { Flex } from '@l.x/ui/src'
 import { AppsOverview } from '~/pages/Landing/sections/AppsOverview'
 import { Footer } from '~/pages/Landing/sections/Footer'
+import { LiquidityBanner } from '~/pages/Landing/sections/LiquidityBanner'
 import { NewsletterEtc } from '~/pages/Landing/sections/NewsletterEtc'
 import { Stats } from '~/pages/Landing/sections/Stats'
 
@@ -18,6 +19,7 @@ const Fold = forwardRef<HTMLDivElement>(function Fold(_props, scrollAnchor) {
       ref={scrollAnchor}
     >
       <Stats />
+      <LiquidityBanner />
       <AppsOverview />
       <NewsletterEtc />
       <Footer />

--- a/apps/web/src/pages/Landing/sections/LiquidityBanner.tsx
+++ b/apps/web/src/pages/Landing/sections/LiquidityBanner.tsx
@@ -1,0 +1,56 @@
+import { Flex, styled, Text } from '@l.x/ui/src'
+
+const Container = styled(Flex, {
+  width: '100%',
+  maxWidth: 1360,
+  alignItems: 'center',
+  px: 40,
+  $lg: { px: 48 },
+  $sm: { px: 24 },
+})
+
+const Card = styled(Flex, {
+  width: '100%',
+  maxWidth: 1280,
+  borderRadius: '$rounded24',
+  backgroundColor: '$surface2',
+  borderColor: '$surface3',
+  borderWidth: 1,
+  py: '$spacing24',
+  px: '$spacing32',
+  gap: '$spacing12',
+  $sm: { px: '$spacing20', py: '$spacing20' },
+})
+
+// Static, non-animated statement. The $113T figure references global asset liquidity now
+// reachable on-chain through Liquidity.io (regulated ATS routing).
+export function LiquidityBanner() {
+  return (
+    <Container>
+      <Card row $md={{ flexDirection: 'column', alignItems: 'flex-start', gap: '$spacing16' }} alignItems="center" justifyContent="space-between">
+        <Flex gap="$spacing4" flex={1}>
+          <Text variant="heading3" $md={{ variant: 'subheading1' }}>$113T in regulated asset liquidity</Text>
+          <Text variant="body2" color="$neutral2">
+            Trade against $113 trillion in global regulated asset liquidity, settled on-chain through Liquidity.io.
+          </Text>
+        </Flex>
+        <a
+          href="https://liquidity.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: 'none' }}
+        >
+          <Flex
+            backgroundColor="$accent1"
+            borderRadius="$rounded24"
+            px="$spacing20"
+            py="$spacing12"
+            hoverStyle={{ opacity: 0.9 }}
+          >
+            <Text variant="buttonLabel2" color="$white">Learn more</Text>
+          </Flex>
+        </a>
+      </Card>
+    </Container>
+  )
+}

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router'
 import type { SegmentedControlOption } from '@l.x/ui/src'
-import { Flex, SegmentedControl, styled, Text, Tooltip } from '@l.x/ui/src'
+import { Flex, SegmentedControl, styled, Text, Tooltip, TouchableArea } from '@l.x/ui/src'
 import type { AppTFunction } from '@l.x/ui/src/i18n/types'
 import { zIndexes } from '@l.x/ui/src/theme'
 import { useLuxContext } from '@l.x/lx/src/contexts/LuxContext'
@@ -52,6 +52,7 @@ import { SwapAndLimitContextProvider } from '~/state/swap/SwapContext'
 import type { CurrencyState } from '~/state/swap/types'
 import { useSwapAndLimitContext } from '~/state/swap/useSwapContext'
 import { isIFramed } from '~/utils/isIFramed'
+import { isOnboarded, isRegulatedToken, onboardingUrlFor } from '~/utils/regulated'
 
 export default function SwapPage() {
   const navigate = useNavigate()
@@ -256,8 +257,21 @@ function UniversalSwapFlow({
   /** When Swap is embedded in TDP, the TDP token currency for Buy/Sell prefill */
   tdpCurrency?: Currency
 }) {
-  const { currentTab, setCurrentTab } = useSwapAndLimitContext()
+  const { currentTab, setCurrentTab, currencyState } = useSwapAndLimitContext()
   const tdpCurrencyAsset = currencyToAsset(tdpCurrency)
+
+  // Liquid EVM regulated-securities gate: route the user through Liquidity onboarding
+  // before letting them swap any token whose chain is Liquid EVM.
+  const regulatedChainId =
+    (isRegulatedToken(currencyState.inputCurrency) && currencyState.inputCurrency?.chainId) ||
+    (isRegulatedToken(currencyState.outputCurrency) && currencyState.outputCurrency?.chainId) ||
+    undefined
+  const showOnboardGate = !!regulatedChainId && !isOnboarded()
+  const onOnboardClick = useCallback(() => {
+    if (regulatedChainId) {
+      window.open(onboardingUrlFor(regulatedChainId), '_blank', 'noopener,noreferrer')
+    }
+  }, [regulatedChainId])
 
   const { pathname } = useLocation()
   const navigate = useNavigate()
@@ -342,20 +356,47 @@ function UniversalSwapFlow({
       )}
       {currentTab === SwapTab.Swap && (
         <Flex gap="$spacing16">
-          <SwapDependenciesStoreContextProvider swapHandlers={swapHandlers}>
-            <SwapFlow
-              settings={swapSettings}
-              hideHeader={hideHeader}
-              hideFooter={hideFooter}
-              onClose={noop}
-              swapRedirectCallback={swapRedirectCallback}
-              onCurrencyChange={onCurrencyChange}
-              prefilledState={prefilledState}
-              tokenColor={tokenColor}
-              onSubmitSwap={resetDisableOneClickSwap}
-              passkeyAuthStatus={passkeyAuthStatus}
-            />
-          </SwapDependenciesStoreContextProvider>
+          <Flex position="relative">
+            <SwapDependenciesStoreContextProvider swapHandlers={swapHandlers}>
+              <SwapFlow
+                settings={swapSettings}
+                hideHeader={hideHeader}
+                hideFooter={hideFooter}
+                onClose={noop}
+                swapRedirectCallback={swapRedirectCallback}
+                onCurrencyChange={onCurrencyChange}
+                prefilledState={prefilledState}
+                tokenColor={tokenColor}
+                onSubmitSwap={resetDisableOneClickSwap}
+                passkeyAuthStatus={passkeyAuthStatus}
+              />
+            </SwapDependenciesStoreContextProvider>
+            {showOnboardGate && (
+              <Flex
+                position="absolute"
+                bottom={0}
+                left={0}
+                right={0}
+                p="$spacing12"
+                zIndex={zIndexes.overlay}
+              >
+                <TouchableArea
+                  onPress={onOnboardClick}
+                  alignItems="center"
+                  justifyContent="center"
+                  borderRadius="$rounded20"
+                  backgroundColor="$accent1"
+                  py="$spacing16"
+                  hoverStyle={{ opacity: 0.9 }}
+                  pressStyle={{ opacity: 0.85 }}
+                >
+                  <Text variant="buttonLabel1" color="$white">
+                    Onboard Now
+                  </Text>
+                </TouchableArea>
+              </Flex>
+            )}
+          </Flex>
           <SwapBottomCard />
         </Flex>
       )}

--- a/apps/web/src/utils/regulated.ts
+++ b/apps/web/src/utils/regulated.ts
@@ -1,0 +1,25 @@
+// Liquid EVM (regulated securities) chain ids and the corresponding Liquidity onboarding flow.
+// Source of truth: ~/work/zoo/exchange/featured-tokens.ts (mainnet/testnet/devnet).
+
+const LIQUID_EVM_CHAIN_IDS = new Set<number>([8675309, 8675310, 8675311])
+
+const ONBOARDING_BY_CHAIN: Record<number, string> = {
+  8675309: 'https://id.satschel.com/onboarding',
+  8675310: 'https://id.test.satschel.com/onboarding',
+  8675311: 'https://id.dev.satschel.com/onboarding',
+}
+
+export function isRegulatedToken(token: { chainId?: number } | undefined | null): boolean {
+  return !!token?.chainId && LIQUID_EVM_CHAIN_IDS.has(token.chainId)
+}
+
+export function onboardingUrlFor(chainId: number | undefined): string {
+  if (chainId && ONBOARDING_BY_CHAIN[chainId]) {
+    return ONBOARDING_BY_CHAIN[chainId]
+  }
+  return ONBOARDING_BY_CHAIN[8675309]
+}
+
+export function isOnboarded(): boolean {
+  return typeof window !== 'undefined' && window.localStorage.getItem('liquidity_onboarded') === 'true'
+}


### PR DESCRIPTION
## Summary
- Landing: static $113T liquidity statement linking to https://liquidity.io, placed between Stats and AppsOverview (no animation, no fake counter)
- Swap: when either side of the pair is on Liquid EVM (8675309/8675310/8675311) and the user has not flipped `localStorage.liquidity_onboarded`, overlay an `Onboard Now` button that opens the chain-appropriate `id.[test.|dev.]satschel.com/onboarding` URL in a new tab
- Tiny shared helper at `apps/web/src/utils/regulated.ts` (no deps, no provider, no API)
- The existing Swap/Approve/Wrap state machine is untouched

## Files
- `apps/web/src/utils/regulated.ts` (new)
- `apps/web/src/pages/Landing/sections/LiquidityBanner.tsx` (new)
- `apps/web/src/pages/Landing/Fold.tsx` (1 import + 1 element)
- `apps/web/src/pages/Swap/index.tsx` (1 import, gate state inside `UniversalSwapFlow`, overlay above SwapFlow)

## Test plan
- [ ] Visit `/` and confirm the $113T banner renders between Stats and AppsOverview, with a working `Learn more` external link
- [ ] On `/swap`, pick a Liquid EVM token (e.g. AAPL on chain 8675309) for either side; confirm `Onboard Now` overlays the swap CTA
- [ ] Click `Onboard Now`; confirm a new tab opens to `https://id.satschel.com/onboarding` (mainnet) / `https://id.test.satschel.com/onboarding` (testnet) / `https://id.dev.satschel.com/onboarding` (devnet)
- [ ] Set `localStorage.setItem('liquidity_onboarded','true')`; reload; confirm the gate is gone and the normal swap CTA returns
- [ ] Pick a non-Liquid-EVM pair; confirm no overlay